### PR TITLE
レビュー後の修正

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -8,7 +8,7 @@ class UsersController < ApplicationController
   def create
     @user = User.new(user_params)
     if @user.save
-      redirect_to root_path, success: t("users.create.success")
+      redirect_to login_path, success: t("users.create.success")
     else
       flash.now[:danger] = t("users.create.failure")
       render :new, status: :unprocessable_entity

--- a/app/javascript/plan.js
+++ b/app/javascript/plan.js
@@ -1,7 +1,10 @@
-document.addEventListener("DOMContentLoaded", function() {
+document.addEventListener("turbo:load", function() {
   const addPlanButton = document.getElementById("add-plan-button");
   const planContainer = document.getElementById("add-container");
-  let planIndex = document.querySelectorAll('.plan-form').length;
+  let planIndex = document.querySelectorAll('.plan').length;
+
+  if (!addPlanButton) { return false; }
+  if (!planContainer) { return false; }
 
   function addPlan() {
     const planHtml = `
@@ -20,7 +23,7 @@ document.addEventListener("DOMContentLoaded", function() {
               <input type="time" name="book[plans_attributes][${planIndex}][start_time]" class="form-control" />
             </div>
             <div class="col-md-9 mb-3">
-              <textarea name="book[plans_attributes][${planIndex}][detail]" class="form-control" placeholder="詳細"></textarea>
+              <textarea name="book[plans_attributes][${planIndex}][detail]" class="form-control" placeholder="詳細" ></textarea>
             </div>
           </div>
         </div>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,6 +1,9 @@
 <div class="container">
   <div class="row">
     <div class="col-md-10 col-lg-8 mx-auto my-5 py-4">
+      <p class="text-danger">
+        *は必須項目です
+      </p>
       <%= form_with model: @user do |f| %>
         <%= render "shared/error_messages", object: f.object %>
         <div class="mb-3">

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -6,11 +6,11 @@ ja:
       plan: プラン
     attributes:
       user:
-        email: メールアドレス
+        email: メールアドレス*
         gender: 性別
         age_group: 年代
-        password: パスワード
-        password_confirmation: パスワード確認
+        password: パスワード*
+        password_confirmation: パスワード確認*
       book:
         title: タイトル
         image: 背景


### PR DESCRIPTION
 - 会員登録後の遷移をトップページからログインページへ変更しました。
 - 会員登録時の入力必須項目についてページに記述追加しました。（性別、年代は任意としていましたが、明示していなかったため修正しました。）
 - しおり新規作成時、編集時のプラン追加ボタンの挙動について修正しました。