### PR TITLE
デプロイ環境でのエラー部分を修正

### DIFF
--- a/db/migrate/20241115221617_sorcery_reset_password.rb
+++ b/db/migrate/20241115221617_sorcery_reset_password.rb
@@ -1,6 +1,5 @@
 class SorceryResetPassword < ActiveRecord::Migration[7.2]
   def change
-    add_column :users, :reset_password_email_sent_at, :datetime, default: nil
     add_column :users, :access_count_to_reset_password_page, :integer, default: 0
 
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -67,7 +67,6 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_15_221617) do
     t.datetime "updated_at", null: false
     t.string "reset_password_token"
     t.datetime "reset_password_token_expires_at"
-    t.datetime "reset_password_email_sent_at"
     t.integer "access_count_to_reset_password_page", default: 0
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true


### PR DESCRIPTION
デプロイ時のエラーを修正。
```
ActiveRecord::StatementInvalid: PG::DuplicateColumn: ERROR:  column "reset_password_email_sent_at" of relation "users" already exists (ActiveRecord::StatementInvalid)
PG::DuplicateColumn: ERROR:  column "reset_password_email_sent_at" of relation "users" already exists (PG::DuplicateColumn)
```
マイグレーションファイルの重複部分を削除し、再度migration。
